### PR TITLE
Sort entries alphabetically

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -148,6 +148,8 @@ CpuTemperature.prototype = {
             }
         }
 
+        items.sort();
+
         this.statusLabel.set_text(this.title);
         this.menu.box.get_children().forEach(function(c) {
             c.destroy()


### PR DESCRIPTION
The current implementation orders the read temperature data as it was reported out by _sensors_. A better approach may be to sort the output alphabetically by label.
