### PR TITLE
GLib.find_program_in_path() is used instead of spawning which

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -63,14 +63,11 @@ CpuTemperature.prototype = {
     },
 
     _detectHDDTemp: function(){
-        //detect if hddtemp is installed
-        let hddtempPath = null;
-        let ret = GLib.spawn_command_line_sync("which hddtemp");
-        if ( (ret[0]) && (ret[3] == 0) ) {//if yes
-            hddtempPath =ret[1].toString().split("\n", 1)[0];
-            // for any reason it is not possible to run hddtemp directly.
+        let hddtempPath = GLib.find_program_in_path('hddtemp');
+        if(hddtempPath) {
+            // check if this user can run hddtemp directly.
             if(GLib.spawn_command_line_sync(hddtempPath)[3])
-                hddtempPath = null;
+                hddtempPath = '';
         }
         return hddtempPath;
     },


### PR DESCRIPTION
Hello xtranophilist,

this pull request replaces the implementation of _detectHDDTemp that used the 'which' executable to locate hddtemp. The new implementation uses GLib.find_program_in_path instead to follow the idea of commit SHA: 9fe9a4f112070870922dbdc3470553a04b38f918

regards

Marcel Metz
