### PR TITLE
Separator between sensors data and preferences

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -170,6 +170,9 @@ CpuTemperature.prototype = {
         let _appSys = Shell.AppSystem.get_default();
         let _gsmPrefs = _appSys.lookup_app('gnome-shell-extension-prefs.desktop');
 
+        // separator
+        section.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
+
         let item = new PopupMenu.PopupMenuItem(_("Preferences..."));
         item.connect('activate', function () {
             if (_gsmPrefs.get_state() == _gsmPrefs.SHELL_APP_STATE_RUNNING){


### PR DESCRIPTION
I added a separator item between sensors values and preferences button in the popup menu, similarly to the others popup menus like sound volume and network.

If you like it, in the future we could think about adding separators even between sensor data from different adapters (HDDs, CPUs, motherboard, etc...)
