### PR TITLE
Add voltage and fan RPM to display.

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -89,6 +89,7 @@ CpuTemperature.prototype = {
 
     _updateDisplay: function() {
         let display_fan_rpm  = settings.get_boolean('display-fan-rpm');
+        let display_voltage  = settings.get_boolean('display-voltage');
         let tempItems = new Array();
         let fanItems = new Array();
         let voltageItems = new Array();
@@ -127,7 +128,7 @@ CpuTemperature.prototype = {
                     }
                 }
             }
-            if(sensors_output[0]) voltageInfo = this._parseSensorsOutput(sensors_output[1].toString(),this._parseVoltageLine.bind(this));//get voltage from sensors
+            if(display_voltage && sensors_output[0]) voltageInfo = this._parseSensorsOutput(sensors_output[1].toString(),this._parseVoltageLine.bind(this));//get voltage from sensors
             if (voltageInfo){
                 for (let voltage in voltageInfo){
                     voltageItems.push(voltageInfo[voltage]['label']+': '+voltageInfo[voltage]['volt']+'V');

--- a/prefs.js
+++ b/prefs.js
@@ -67,6 +67,11 @@ const CPUTemperaturePrefsWidget = new GObject.Class({
                 label: _("Display fan RPM"),
                 help: _("Show the fan rotations per minute. (default: ON)")
            },
+           show_voltage: {
+                name: _("display-voltage"),
+                label: _("Display voltage"),
+                help: _("Show the voltage of various components. (default: ON)")
+           },
         }
 
         let counter = 3;

--- a/schemas/org.gnome.shell.extensions.cpu-temperature.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.cpu-temperature.gschema.xml
@@ -45,5 +45,11 @@
       <description>Display fan rotation per minute.</description>
     </key>
 
+    <key type="b" name="display-voltage">
+      <default>true</default>
+      <summary>Display voltage</summary>
+      <description>Display voltage of various components.</description>
+    </key>
+
   </schema>
 </schemalist>


### PR DESCRIPTION
I would like to know if it would be in the scope of this extension to display the other measured data like fan RPM speed or the voltage. In my opinion such a feature would fit in nicely.
