### PR TITLE
Fix for Sensors Settings not opening

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -7,6 +7,8 @@ uuid = temperature@xtranophilist
 
 extensiondir = $(topextensiondir)/$(uuid)
 
+dist_extension_DATA = stylesheet.css
+
 nodist_extension_DATA = metadata.json $(EXTRA_EXTENSION)
 
 EXTRA_DIST = metadata.json.in

--- a/data/metadata.json.in
+++ b/data/metadata.json.in
@@ -5,7 +5,8 @@
   "gettext-domain": "@GETTEXT_PACKAGE@",
   "shell-version": [
     "3.10",
-    "3.12"
+    "3.12",
+    "3.14"
   ],
   "localedir": "@LOCALEDIR@",
   "url": "@url@", 

--- a/data/stylesheet.css
+++ b/data/stylesheet.css
@@ -1,0 +1,4 @@
+.extension-sensors-main-sensor-label {
+    text-align: center;
+    font-weight: bold;
+}

--- a/po/es.po
+++ b/po/es.po
@@ -80,31 +80,31 @@ msgstr "Fahrenheit"
 
 #: ../src/prefs.js:56
 msgid "Display temperature unit"
-msgstr "Monstrar unidad de temperatura"
+msgstr "Mostrar unidad de temperatura"
 
 #: ../src/prefs.js:57
 msgid "Show temperature unit in panel and menu."
-msgstr "Monstrar unidad de temperatura en panel y menú"
+msgstr "Mostrar unidad de temperatura en panel y menú"
 
 #: ../src/prefs.js:61
 msgid "Display decimal value"
-msgstr "Monstrar el valor decimal"
+msgstr "Mostrar el valor decimal"
 
 #: ../src/prefs.js:62
 msgid "Show one digit after decimal."
-msgstr "Monstrar un dígito después del decimal"
+msgstr "Mostrar un dígito después del decimal"
 
 #: ../src/prefs.js:66
 msgid "Display drive temperature"
-msgstr "Monstrar la temperatura de disco duro"
+msgstr "Mostrar la temperatura de disco duro"
 
 #: ../src/prefs.js:70
 msgid "Display fan speed"
-msgstr "Monstrar velocidad del ventilador"
+msgstr "Mostrar velocidad del ventilador"
 
 #: ../src/prefs.js:74
 msgid "Display power supply voltage"
-msgstr "Monstrar voltaje de la fuente de poder"
+msgstr "Mostrar voltaje de la fuente de poder"
 
 #: ../src/prefs.js:129
 msgid "Sensor in panel"
@@ -112,7 +112,7 @@ msgstr "Sensor en panel"
 
 #: ../src/prefs.js:133
 msgid "Display sensor label"
-msgstr "Monstrar etiquetas del sensores"
+msgstr "Mostrar etiquetas del sensores"
 
 #: ../src/utilities.js:157
 #, c-format

--- a/src/extension.js
+++ b/src/extension.js
@@ -189,9 +189,6 @@ const SensorsMenuButton = new Lang.Class({
                 section.addMenuItem(item);
             }
 
-            let _appSys = Shell.AppSystem.get_default();
-            let _gsmPrefs = _appSys.lookup_app('gnome-shell-extension-prefs.desktop');
-
             // separator
             section.addMenuItem(new PopupMenu.PopupSeparatorMenuItem());
 
@@ -201,12 +198,12 @@ const SensorsMenuButton = new Lang.Class({
             item.actor.add(new St.Label({ text: '' }));
             item.actor.add(new St.Label({ text: _("Sensors Settings") }));
             item.connect('activate', function () {
-                if (_gsmPrefs.get_state() == _gsmPrefs.SHELL_APP_STATE_RUNNING){
-                    _gsmPrefs.activate();
-                } else {
-                    _gsmPrefs.launch(global.display.get_current_time_roundtrip(),
-                                     [metadata.uuid],-1,null);
-                }
+                let appSys = Shell.AppSystem.get_default();
+                let app = appSys.lookup_app('gnome-shell-extension-prefs.desktop');
+                let info = app.get_app_info();
+                let timestamp = global.display.get_current_time_roundtrip();
+                info.launch_uris(['extension:///' + uuid],
+                                 global.create_app_launch_context(timestamp, -1));
             });
             section.addMenuItem(item);
         }else{

--- a/src/extension.js
+++ b/src/extension.js
@@ -197,14 +197,14 @@ const SensorsMenuButton = new Lang.Class({
             // Label to switch columns and not totally break the layout.
             item.actor.add(new St.Label({ text: '' }));
             item.actor.add(new St.Label({ text: _("Sensors Settings") }));
-            item.connect('activate', function () {
+            item.connect('activate', Lang.bind(this, function () {
                 let appSys = Shell.AppSystem.get_default();
                 let app = appSys.lookup_app('gnome-shell-extension-prefs.desktop');
                 let info = app.get_app_info();
                 let timestamp = global.display.get_current_time_roundtrip();
-                info.launch_uris(['extension:///' + uuid],
+                info.launch_uris(['extension:///' + metadata.uuid],
                                  global.create_app_launch_context(timestamp, -1));
-            });
+            }));
             section.addMenuItem(item);
         }else{
             this.statusLabel.set_text(_("Error"));

--- a/src/extension.js
+++ b/src/extension.js
@@ -41,7 +41,7 @@ const SensorsItem = new Lang.Class({
     },
 
     setMainSensor: function() {
-        this.setOrnament(PopupMenu.Ornament.DOT);
+        this.actor.add_style_class_name('extension-sensors-main-sensor-label');
     },
 
     getLabel: function() {

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -77,7 +77,7 @@ const SensorsPrefsWidget = new GObject.Class({
 
         let counter = 3;
 
-        for (boolSetting in boolSettings){
+        for (let boolSetting in boolSettings){
             let setting = boolSettings[boolSetting];
             let settingLabel = new Gtk.Label({ label: setting.label });
             let settingSwitch = new Gtk.Switch({active: this._settings.get_boolean(setting.name)});


### PR DESCRIPTION
This should fix the issue with 'Sensors Settings' shortcut not launching gnome-shell-extension-prefs tool on Gnome 3.12.
I also restored the bold font (using stylesheet) to indicate the main sensor as the dot is not aligned and doesn't look good.
Tested on Debian testing with Gnome Shell 3.12.2.