### PR TITLE
Add GNOME Shell 3.14 support and fix a typo

### DIFF
--- a/data/metadata.json.in
+++ b/data/metadata.json.in
@@ -5,7 +5,8 @@
   "gettext-domain": "@GETTEXT_PACKAGE@",
   "shell-version": [
     "3.10",
-    "3.12"
+    "3.12",
+    "3.14"
   ],
   "localedir": "@LOCALEDIR@",
   "url": "@url@", 

--- a/po/es.po
+++ b/po/es.po
@@ -80,31 +80,31 @@ msgstr "Fahrenheit"
 
 #: ../src/prefs.js:56
 msgid "Display temperature unit"
-msgstr "Monstrar unidad de temperatura"
+msgstr "Mostrar unidad de temperatura"
 
 #: ../src/prefs.js:57
 msgid "Show temperature unit in panel and menu."
-msgstr "Monstrar unidad de temperatura en panel y menú"
+msgstr "Mostrar unidad de temperatura en panel y menú"
 
 #: ../src/prefs.js:61
 msgid "Display decimal value"
-msgstr "Monstrar el valor decimal"
+msgstr "Mostrar el valor decimal"
 
 #: ../src/prefs.js:62
 msgid "Show one digit after decimal."
-msgstr "Monstrar un dígito después del decimal"
+msgstr "Mostrar un dígito después del decimal"
 
 #: ../src/prefs.js:66
 msgid "Display drive temperature"
-msgstr "Monstrar la temperatura de disco duro"
+msgstr "Mostrar la temperatura de disco duro"
 
 #: ../src/prefs.js:70
 msgid "Display fan speed"
-msgstr "Monstrar velocidad del ventilador"
+msgstr "Mostrar velocidad del ventilador"
 
 #: ../src/prefs.js:74
 msgid "Display power supply voltage"
-msgstr "Monstrar voltaje de la fuente de poder"
+msgstr "Mostrar voltaje de la fuente de poder"
 
 #: ../src/prefs.js:129
 msgid "Sensor in panel"
@@ -112,7 +112,7 @@ msgstr "Sensor en panel"
 
 #: ../src/prefs.js:133
 msgid "Display sensor label"
-msgstr "Monstrar etiquetas del sensores"
+msgstr "Mostrar etiquetas del sensores"
 
 #: ../src/utilities.js:157
 #, c-format


### PR DESCRIPTION
I've tested this on Arch Linux and everything seems to be working alright.