### PR TITLE
Update metadata.json.in for 3.14

### DIFF
--- a/data/metadata.json.in
+++ b/data/metadata.json.in
@@ -5,7 +5,8 @@
   "gettext-domain": "@GETTEXT_PACKAGE@",
   "shell-version": [
     "3.10",
-    "3.12"
+    "3.12",
+    "3.14"
   ],
   "localedir": "@LOCALEDIR@",
   "url": "@url@", 


### PR DESCRIPTION
Extension works as-is in 3.14. Version number is updated accordingly.