### PR TITLE
Fix icon size

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -28,7 +28,7 @@ const SensorsItem = new Lang.Class({
         this._label = label;
         this._value = value;
 
-        this.actor.add(new St.Icon({ style_class: 'system-status-icon', icon_name: 'sensors-'+type+'-symbolic' }));
+        this.actor.add(new St.Icon({ style_class: 'system-status-icon', icon_name: 'sensors-'+type+'-symbolic', icon_size: 16 }));
         this.actor.add(new St.Label({text: label}));
         this.actor.add(new St.Label({text: value}), {align: St.Align.END});
     },


### PR DESCRIPTION
On my Fedora 22 with GNOME Shell 3.16.2 in classic mode, sensors icons have very biggest size
![sensors_ext_bug](https://cloud.githubusercontent.com/assets/28865/8447654/72b194de-1fd5-11e5-8a50-7d49551a97bb.png)

This patch fix it.